### PR TITLE
#26 Fix costs API: Money.value sometimes returned as JSON string causing unmarshal error

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +46,29 @@ func (s *StringOrBool) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 	return fmt.Errorf("unsupported type for StringOrBool: %s", string(b))
+}
+
+type FloatOrString float64
+
+func (f *FloatOrString) UnmarshalJSON(data []byte) error {
+	var floatVal float64
+	if err := json.Unmarshal(data, &floatVal); err == nil {
+		*f = FloatOrString(floatVal)
+		return nil
+	}
+
+	var strVal string
+	if err := json.Unmarshal(data, &strVal); err != nil {
+		return err
+	}
+
+	floatVal, err := strconv.ParseFloat(strVal, 64)
+	if err != nil {
+		return err
+	}
+
+	*f = FloatOrString(floatVal)
+	return nil
 }
 
 // Global Variables and State
@@ -173,8 +197,8 @@ type CostBucket struct {
 }
 
 type Money struct {
-	Value    float64 `json:"value"`
-	Currency string  `json:"currency"`
+	Value    FloatOrString `json:"value"`
+	Currency string        `json:"currency"`
 }
 
 type CostResult struct {
@@ -490,7 +514,7 @@ func (e *Exporter) fetchCostData(startTime, endTime int64) error {
 					"organization_id": res.OrganizationID,
 					"currency":        res.Amount.Currency,
 				}
-				dailyCostUSD.With(labels).Set(res.Amount.Value)
+				dailyCostUSD.With(labels).Set(float64(res.Amount.Value))
 				logrus.Debugf("Processed result - Date: %s, ProjectID: %s, ProjectName: %s, LineItem: %s, OrganizationID: %s, Cost: %f, Currency: %s",
 					date, projectId, e.ensureProjectName(projectId), lineName, res.OrganizationID, res.Amount.Value, res.Amount.Currency)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -67,6 +67,146 @@ func TestStringOrBool_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestFloatOrString_UnmarshalJSON_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected FloatOrString
+		wantErr  bool
+	}{
+		{
+			name:     "string value",
+			input:    "123.45",
+			expected: 123.45,
+			wantErr:  false,
+		},
+		{
+			name:     "string value many zeros",
+			input:    "0.1739150000000000000000000000",
+			expected: 0.173915,
+			wantErr:  false,
+		},
+		{
+			name:     "int as string",
+			input:    "73",
+			expected: 73.0,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid string value",
+			input:    "foo",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid type",
+			input:    `[]`,
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f FloatOrString
+			err := json.Unmarshal([]byte(tt.input), &f)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, f)
+			}
+		})
+	}
+}
+
+func TestFloatOrString_UnmarshalJSON_Float(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected FloatOrString
+		wantErr  bool
+	}{
+		{
+			name:     "2 decimals",
+			input:    123.45,
+			expected: 123.45,
+			wantErr:  false,
+		},
+		{
+			name:     "6 decimals",
+			input:    0.173915,
+			expected: 0.173915,
+			wantErr:  false,
+		},
+		{
+			name:     "int",
+			input:    73,
+			expected: 73.0,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f FloatOrString
+			b, errMarshal := json.Marshal(tt.input)
+			assert.NoError(t, errMarshal)
+			err := json.Unmarshal(b, &f)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, f)
+			}
+		})
+	}
+}
+
+func TestMoney_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Money
+		wantErr  bool
+	}{
+		{
+			name:  "string value",
+			input: `{"currency": "usd", "value": "0.1739150000000000000000000000"}`,
+			expected: Money{
+				Value:    0.173915,
+				Currency: "usd",
+			},
+			wantErr: false,
+		},
+		{
+			name:  "float64 value",
+			input: `{"currency": "usd", "value": 0.173915}`,
+			expected: Money{
+				Value:    0.173915,
+				Currency: "usd",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m Money
+			err := json.Unmarshal([]byte(tt.input), &m)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, m)
+			}
+		})
+	}
+}
+
 func TestDeref(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Hello,

The PR should fix the issue described in #26.

We add support for handling values that can be represented either as a float or as a string by introducing a new `FloatOrString` type.
This follows the same approach as the existing `StringOrBool` implementation already used in the project.
