### PR TITLE
docs: explicitly state that admin key is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/foxdalas/openai-exporter?style=flat-square)](https://hub.docker.com/r/foxdalas/openai-exporter) [![GitHub Release](https://img.shields.io/github/v/release/foxdalas/openai-exporter?style=flat-square)](https://github.com/foxdalas/openai-exporter/releases)
 
-
-
 # OpenAI Exporter
 
 This is an OpenAI Prometheus Exporter designed to fetch and expose usage data metrics from OpenAI's APIs. The exporter provides metrics related to the utilization of various OpenAI services, such as completions, embeddings, and moderations, suitable for monitoring and analytics purposes.
@@ -30,47 +28,52 @@ This is an OpenAI Prometheus Exporter designed to fetch and expose usage data me
 ## Configuration
 
 Before running the exporter, ensure the following environment variables are set:
-- `OPENAI_SECRET_KEY`: Your OpenAI API secret key.
-- `OPENAI_ORG_ID`: Your organization ID with OpenAI.
+- `OPENAI_SECRET_KEY`: Your OpenAI API secret key, this can be [admin read only key](https://platform.openai.com/settings/organization/admin-keys)
+- `OPENAI_ORG_ID`: Your organization ID with OpenAI, you can see it [here](https://platform.openai.com/settings/organization/general)
 
-## Installation
+## Building binary
 
-```bash
+```shell
 go build -o openai-exporter
 ```
 
 ## Usage
-```
+
+```shell
 ./openai-exporter
 ```
 
 ### Docker
-```
-docker run -d -p 9185:9185 -e OPENAI_SECRET_KEY=your_secret_key -e OPENAI_ORG_ID=your_org_id foxdalas/openai-exporter:v0.0.11
+
+```shell
+docker run -d -p 9185:9185 -e OPENAI_SECRET_KEY=your_secret_key -e OPENAI_ORG_ID=your_org_id foxdalas/openai-exporter:v0.0.16
 ```
 
 Use the following flags to customize the behavior:
 
-* `-web.listen-address`: Set the listen address for the web interface and telemetry (default: :9185).
-* `-web.telemetry-path`: Set the path under which to expose metrics (default: /metrics).
-* `-scrape.interval`: Set the interval for API calls and data collection (default: 1m).
-* `-log.level`: Set the log verbosity (default: info).
+* `-web.listen-address`: Set the listen address for the web interface and telemetry (default: `:9185`).
+* `-web.telemetry-path`: Set the path under which to expose metrics (default: `/metrics`).
+* `-scrape.interval`: Set the interval for API calls and data collection (default: `1m`).
+* `-log.level`: Set the log verbosity (default: `info`).
 
 ## How It Works
 
 ### Token Metrics Collection
+
 - Fetches usage data every minute (configurable via `-scrape.interval`)
 - Collects data in 1-minute buckets with automatic deduplication
 - Aggregates metrics by model, operation, project, user, API key, and batch status
 - Only processes completed time buckets to ensure data accuracy
 
 ### Cost Metrics Collection
+
 - Fetches daily cost data every 24 hours
 - Initial fetch covers the last 2 days
 - Groups costs by project with line-item breakdown
 - Supports multiple currencies (indicated by the `currency` label)
 
 ### Project Name Enrichment
+
 - Automatically resolves project IDs to human-readable names
 - Caches project names to minimize API calls
 - Falls back to "unknown" if project name cannot be resolved
@@ -80,6 +83,7 @@ Use the following flags to customize the behavior:
 The exporter provides two main metrics:
 
 ### `openai_api_tokens_total`
+
 Counter metric tracking token usage across all operations.
 
 **Labels:**
@@ -93,6 +97,7 @@ Counter metric tracking token usage across all operations.
 - `token_type`: Type of tokens (`input`, `output`, `input_cached`, `input_audio`, `output_audio`)
 
 ### `openai_api_daily_cost`
+
 Gauge metric tracking daily costs per project.
 
 **Labels:**
@@ -104,7 +109,8 @@ Gauge metric tracking daily costs per project.
 - `currency`: Currency code (e.g., `usd`)
 
 ### Example Output
-```
+
+```promql
 openai_api_tokens_total{api_key_id="",batch="false",model="gpt-4-turbo-2024-04-09",operation="completions",project_id="",project_name="production",token_type="input",user_id=""} 1081
 openai_api_tokens_total{api_key_id="",batch="false",model="gpt-4-turbo-2024-04-09",operation="completions",project_id="",project_name="production",token_type="input_audio",user_id=""} 0
 openai_api_tokens_total{api_key_id="",batch="false",model="gpt-4-turbo-2024-04-09",operation="completions",project_id="",project_name="production",token_type="input_cached",user_id=""} 0
@@ -114,10 +120,12 @@ openai_api_daily_cost{currency="usd",date="2024-01-15",line_item="GPT-4 Turbo",o
 ```
 
 ## Contributing
+
 Contributions to the OpenAI Exporter are welcome. Please ensure that your commits meet the following criteria:
 * Code must be well-documented.
 * Commits must be clear and concise.
 * All changes must be tested thoroughly.
 
 ## License
+
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/foxdalas/openai-exporter/blob/master/LICENSE) file for details.


### PR DESCRIPTION
* update details where to get API key and with what permissions it needs, because this does not work with project scoped keys, and this is only visible when enabling debug logging and seeing 403 errors from the API (otherwise it is totally hidden)
* use generic shell and text formatting for code blocks
* markdown formatting